### PR TITLE
fix: correct migration guide links

### DIFF
--- a/docs/2020/dokku-0.20.0.md
+++ b/docs/2020/dokku-0.20.0.md
@@ -101,7 +101,7 @@ The `dokku-event-listener` daemon will properly listen to container events - sta
 
 ## Upgrading
 
-As with every upgrade, please see the [0.20.0 migration guide](/docs/appendices/0.20.0-migration-guide/) for more information on upgrading to 0.20.0.
+As with every upgrade, please see the [0.20.0 migration guide](https://dokku.com/docs/appendices/0.20.0-migration-guide/) for more information on upgrading to 0.20.0.
 
 ## Future development
 

--- a/docs/2021/dokku-0.23.0.md
+++ b/docs/2021/dokku-0.23.0.md
@@ -157,7 +157,7 @@ Thanks to [@crisward](https://github.com/crisward) for the inspiration via his [
 
 ## Upgrading
 
-As with every upgrade, please see the [0.23.0 migration guide](/docs/appendices/0.23.0-migration-guide/) for more information on upgrading to 0.23.0.
+As with every upgrade, please see the [0.23.0 migration guide](https://dokku.com/docs/appendices/0.23.0-migration-guide/) for more information on upgrading to 0.23.0.
 
 ## 1.0?
 

--- a/docs/2021/dokku-0.23.x-wrapup.md
+++ b/docs/2021/dokku-0.23.x-wrapup.md
@@ -75,7 +75,7 @@ As of [#4373](https://github.com/dokku/dokku/pull/4373), the Procfile is now ext
 
 ## Upgrading
 
-As with every upgrade, please see the [0.23.0 migration guide](/docs/appendices/0.23.0-migration-guide/) for more information on upgrading to 0.23.0.
+As with every upgrade, please see the [0.23.0 migration guide](https://dokku.com/docs/appendices/0.23.0-migration-guide/) for more information on upgrading to 0.23.0.
 
 ## It's a wrap
 

--- a/docs/2021/dokku-0.24.0.md
+++ b/docs/2021/dokku-0.24.0.md
@@ -102,7 +102,7 @@ If parallelism is needed for a specific command, please file an issue to get it 
 
 ## Upgrading
 
-As with every upgrade, please see the [0.24.0 migration guide](/docs/appendices/0.24.0-migration-guide/) for more information on upgrading to 0.24.0.
+As with every upgrade, please see the [0.24.0 migration guide](https://dokku.com/docs/appendices/0.24.0-migration-guide/) for more information on upgrading to 0.24.0.
 
 ## The Next Minor Release
 

--- a/docs/2021/dokku-0.25.0.md
+++ b/docs/2021/dokku-0.25.0.md
@@ -171,7 +171,7 @@ This functionality can be used when trying to expose non-Dokku maintained servic
 
 ## Upgrading
 
-As with every upgrade, please see the [0.25.0 migration guide](/docs/appendices/0.25.0-migration-guide/) for more information on upgrading to 0.25.0.
+As with every upgrade, please see the [0.25.0 migration guide](https://dokku.com/docs/appendices/0.25.0-migration-guide/) for more information on upgrading to 0.25.0.
 
 ## The Next Minor Release
 

--- a/docs/2021/dokku-0.26.0.md
+++ b/docs/2021/dokku-0.26.0.md
@@ -122,7 +122,7 @@ While there are some limitations, the general Dokku experience works quite well 
 
 ## Upgrading
 
-As with every upgrade, please see the [0.26.0 migration guide](/docs/appendices/0.26.0-migration-guide/) for more information on upgrading to 0.26.0.
+As with every upgrade, please see the [0.26.0 migration guide](https://dokku.com/docs/appendices/0.26.0-migration-guide/) for more information on upgrading to 0.26.0.
 
 ## Dokku Pro
 

--- a/docs/2021/dokku-0.28.0.md
+++ b/docs/2021/dokku-0.28.0.md
@@ -74,7 +74,7 @@ While there are some limitations, the general Dokku experience works quite well 
 
 ## Upgrading
 
-As with every upgrade, please see the [0.28.0 migration guide](/docs/appendices/0.28.0-migration-guide/) for more information on upgrading to 0.28.0.
+As with every upgrade, please see the [0.28.0 migration guide](https://dokku.com/docs/appendices/0.28.0-migration-guide/) for more information on upgrading to 0.28.0.
 
 ## Dokku Pro
 

--- a/docs/2021/dokkus-roaring-20s.md
+++ b/docs/2021/dokkus-roaring-20s.md
@@ -111,7 +111,7 @@ All that said, not all plugins will be rewritten in Golang - the `git` plugin is
 
 ## Upgrading
 
-As with every upgrade, please see the [0.22.0 migration guide](/docs/appendices/0.22.0-migration-guide/) for more information on upgrading to 0.22.0.
+As with every upgrade, please see the [0.22.0 migration guide](https://dokku.com/docs/appendices/0.22.0-migration-guide/) for more information on upgrading to 0.22.0.
 
 ## Future Development
 

--- a/docs/2022/dokku-0.27.x-wrapup.md
+++ b/docs/2022/dokku-0.27.x-wrapup.md
@@ -48,7 +48,7 @@ Some characters should be escaped - and quoting matters! - but label-based proxy
 
 ## Upgrading
 
-As with every upgrade, please see the [0.27.0 migration guide](/docs/appendices/0.27.0-migration-guide/) for more information on upgrading to 0.27.0.
+As with every upgrade, please see the [0.27.0 migration guide](https://dokku.com/docs/appendices/0.27.0-migration-guide/) for more information on upgrading to 0.27.0.
 
 ## It's a wrap
 

--- a/docs/2022/dokku-0.28.x-wrapup.md
+++ b/docs/2022/dokku-0.28.x-wrapup.md
@@ -90,7 +90,7 @@ This fixes issues where users may somehow add an https mapping but are missing a
 
 ## Upgrading
 
-As with every upgrade, please see the [0.28.0 migration guide](/docs/appendices/0.28.0-migration-guide/) for more information on upgrading to 0.28.0.
+As with every upgrade, please see the [0.28.0 migration guide](https://dokku.com/docs/appendices/0.28.0-migration-guide/) for more information on upgrading to 0.28.0.
 
 ## It's a wrap
 

--- a/docs/2022/dokku-0.29.0.md
+++ b/docs/2022/dokku-0.29.0.md
@@ -49,7 +49,7 @@ For more adventurous Dokku users, the herokuish builder can now be enabled on AR
 
 ## Upgrading
 
-As with every upgrade, please see the [0.29.0 migration guide](/docs/appendices/0.29.0-migration-guide/) for more information on upgrading to 0.29.0.
+As with every upgrade, please see the [0.29.0 migration guide](https://dokku.com/docs/appendices/0.29.0-migration-guide/) for more information on upgrading to 0.29.0.
 
 ## Dokku Pro
 

--- a/docs/2023/dokku-0.30.0.md
+++ b/docs/2023/dokku-0.30.0.md
@@ -86,7 +86,7 @@ A recent change in CNB's pack utility changed how processes were launched, causi
 
 ## Upgrading
 
-As with every upgrade, please see the [0.30.0 migration guide](/docs/appendices/0.30.0-migration-guide/) for more information on upgrading to 0.30.0.
+As with every upgrade, please see the [0.30.0 migration guide](https://dokku.com/docs/appendices/0.30.0-migration-guide/) for more information on upgrading to 0.30.0.
 
 ## Dokku Pro
 

--- a/docs/2023/dokku-0.31.0.md
+++ b/docs/2023/dokku-0.31.0.md
@@ -171,7 +171,7 @@ Previously, users on ARM64 machines would not be able to enable traefik's letsen
 
 ## Upgrading
 
-As with every upgrade, please see the [0.31.0 migration guide](/docs/appendices/0.31.0-migration-guide/) for more information on upgrading to 0.31.0.
+As with every upgrade, please see the [0.31.0 migration guide](https://dokku.com/docs/appendices/0.31.0-migration-guide/) for more information on upgrading to 0.31.0.
 
 ## Future Plans
 


### PR DESCRIPTION
In <https://dokku.com/blog/2022/dokku-0.29.0/>,
fist link to migration guide (`Please see the <a href="https://dokku.com/docs/appendices/0.29.0-migration-guide/">migration guide</a> for more details how how this might impact your usage of Dokku.`) is correct.
But second link (`As with every upgrade, please see the <a href="../appendices/0.29.0-migration-guide/">0.29.0 migration guide</a> for more information on upgrading to 0.29.0.`) is broken link to `https://dokku.com/blog/2022/appendices/0.29.0-migration-guide/`.

So, I propose changing the links like second link from path only to full URL like first link.

